### PR TITLE
Prevent infinite recursion when calling toString

### DIFF
--- a/implementation/registry-of-identifiers/src/main/java/eu/efti/identifiersregistry/entity/CarriedTransportEquipment.java
+++ b/implementation/registry-of-identifiers/src/main/java/eu/efti/identifiersregistry/entity/CarriedTransportEquipment.java
@@ -1,10 +1,7 @@
 package eu.efti.identifiersregistry.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Data
@@ -29,6 +26,7 @@ public class CarriedTransportEquipment {
     @Column(name = "id_scheme_agency_id")
     private String schemeAgencyId;
 
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "used_transport_equipment_id", referencedColumnName = "id", insertable = true, updatable = false)
     private UsedTransportEquipment usedTransportEquipment;

--- a/implementation/registry-of-identifiers/src/main/java/eu/efti/identifiersregistry/entity/MainCarriageTransportMovement.java
+++ b/implementation/registry-of-identifiers/src/main/java/eu/efti/identifiersregistry/entity/MainCarriageTransportMovement.java
@@ -1,10 +1,7 @@
 package eu.efti.identifiersregistry.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Data
@@ -32,6 +29,7 @@ public class MainCarriageTransportMovement {
     @Column(name = "used_transport_means_registration_country")
     private String usedTransportMeansRegistrationCountry;
 
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "consignment_id", referencedColumnName = "id", insertable = true, updatable = false)
     private Consignment consignment;

--- a/implementation/registry-of-identifiers/src/main/java/eu/efti/identifiersregistry/entity/UsedTransportEquipment.java
+++ b/implementation/registry-of-identifiers/src/main/java/eu/efti/identifiersregistry/entity/UsedTransportEquipment.java
@@ -2,10 +2,7 @@
 package eu.efti.identifiersregistry.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -40,6 +37,7 @@ public class UsedTransportEquipment {
     @Column(name = "category_code")
     private String categoryCode;
 
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "consignment_id", referencedColumnName = "id", insertable = true, updatable = false)
     private Consignment consignment;


### PR DESCRIPTION
Noticed when logging was on DEBUG level, that printing the entities caused an infinite recursion and StackOverflowError. This takes care of it as the back references should not be followed when printing the object graph.