### PR TITLE
Remove redundant build of project when deploying domibus network

### DIFF
--- a/deploy/local/domibus/deploy.sh
+++ b/deploy/local/domibus/deploy.sh
@@ -1,18 +1,8 @@
 #!/bin/sh
-
-projectPomFile=../../../implementation/pom.xml
-
-echo "Cleaning up..."
-mvn -B clean --file $projectPomFile
-
-echo "Building..."
-mvn -B package --file $projectPomFile
-
-echo "Copying apps..."
-cp -rf ../../../implementation/gate/target/gate-*.jar ./gate/efti-gate.jar
-cp -rf ../../../implementation/platform-simulator/target/platform-simulator-*.jar ./platform/platform-simulator.jar
+set -e
+cd $(dirname $0)
 
 echo "Starting up docker compose"
-docker-compose up -d
+docker compose up -d
 
 $SHELL

--- a/deploy/local/efti-gate/deploy.sh
+++ b/deploy/local/efti-gate/deploy.sh
@@ -2,6 +2,7 @@
 
 # Stop on fail
 set -e
+cd $(dirname $0)
 
 projectPomFile=../../../implementation/pom.xml
 


### PR DESCRIPTION
There was an unused build that was also failing because of changed paths in the project structure