### PR TITLE
Set a minimum length for the follow up text

### DIFF
--- a/schema/xsd/edelivery.xsd
+++ b/schema/xsd/edelivery.xsd
@@ -68,7 +68,8 @@
       <xsd:enumeration value="503">
         <xsd:annotation>
           <xsd:documentation>
-            Service Unavailable - The server cannot handle the request (because it is overloaded or down for maintenance).
+            Service Unavailable - The server cannot handle the request (because it is overloaded or down for
+            maintenance).
             Generally, this is a temporary state.
           </xsd:documentation>
         </xsd:annotation>
@@ -166,7 +167,13 @@
       <xsd:extension base="efti-ed:Request">
         <xsd:sequence>
           <xsd:element name="uil" type="efti-ed:UIL"/>
-          <xsd:element name="message" type="xsd:string"/>
+          <xsd:element name="message">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:minLength value="2"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:element>
         </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>


### PR DESCRIPTION
It doesn't make sense to allow CA to send empty strings as follow up message. Therefore, require them to send at least 2 characters, for example "ok".