### PR TITLE
Correct the container dependencies

### DIFF
--- a/deploy/local/domibus/docker-compose.yml
+++ b/deploy/local/domibus/docker-compose.yml
@@ -102,9 +102,9 @@ services:
       - ./domibus/sh/setenv-node-1.sh:/opt/domibus/bin/setenv.sh
       - ./domibus/li/plugins-conf/:/opt/domibus/conf/domibus/plugins/config/domains/
     depends_on:
-      mariadb-sybo:
+      mariadb-li:
         condition: service_healthy
-      activemq-sybo:
+      activemq-li:
         condition: service_started
     networks:
       efti:
@@ -124,9 +124,9 @@ services:
       - ./domibus/sh/setenv-node-1.sh:/opt/domibus/bin/setenv.sh
       - ./domibus/platform/plugins-conf/:/opt/domibus/conf/domibus/plugins/config/domains/
     depends_on:
-      mariadb-sybo:
+      mariadb-platform:
         condition: service_healthy
-      activemq-sybo:
+      activemq-platform:
         condition: service_started
     networks:
       efti:


### PR DESCRIPTION
The domibus containers were all depending on the same database instances, rather than platform domibus depending on the platorm database etc.

Note that https://github.com/EFTI4EU/reference-implementation/pull/62 will remove some of the replicated instances so I didn't touch those in this PR to avoid conflicts.