### PR TITLE
EREF-27 eFTI Platform identifiers to eFTI Gate REST API interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ More detailed documentation of different elements of this repository can be foun
     - [Common library](implementation/commons/README.md)
     - [Logger](implementation/efti-logger/README.md)
     - [Platform and gate simulator](implementation/platform-gate-simulator/README.md)
+    - [Test support](implementation/test-support/README.md)
 - [Schemas](schema/README.md)
     - [Data models](schema/xsd/README.md)
     - [API definitions](schema/api-schemas/README.md)

--- a/deploy/local/efti-gate/docker-compose.yml
+++ b/deploy/local/efti-gate/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     ports:
       - "8070:8070"
       - "8893:5005"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       efti:
 
@@ -38,6 +40,8 @@ services:
     ports:
       - "8071:8071"
       - "8894:5005"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       efti:
   
@@ -53,6 +57,8 @@ services:
     ports:
       - "8072:8072"
       - "8895:5005"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       efti:
 

--- a/deploy/local/efti-gate/httpd/config/conf.d/efti.conf
+++ b/deploy/local/efti-gate/httpd/config/conf.d/efti.conf
@@ -42,6 +42,20 @@ Define back_base_url "http://host.docker.internal:8880"
         ProxyPassReverse  ${back_base_url}/v1
     </Location>
 
+	<Location "/api/platform">
+        AuthType None
+        Require expr %{HTTP:X-Mock-Pre-Authenticated-User-Id} != ''
+        Require expr %{HTTP:X-Mock-Pre-Authenticated-User-Role} != ''
+
+        RequestHeader unset X-Pre-Authenticated-User-Id
+        RequestHeader unset X-Pre-Authenticated-User-Role
+        RequestHeader set X-Pre-Authenticated-User-Id "expr=%{HTTP:X-Mock-Pre-Authenticated-User-Id}"
+        RequestHeader set X-Pre-Authenticated-User-Role "expr=%{HTTP:X-Mock-Pre-Authenticated-User-Role}"
+
+        ProxyPass  ${back_base_url}/api/platform
+        ProxyPassReverse  ${back_base_url}/api/platform
+    </Location>
+
     <Location "/ws">
         AuthType None
         Require all granted

--- a/deploy/local/efti-gate/platform/application.yml
+++ b/deploy/local/efti-gate/platform/application.yml
@@ -10,3 +10,6 @@ spring:
   output:
     ansi:
       enabled: always
+
+gate:
+  restApiBaseUrl: http://host.docker.internal:83/api/platform

--- a/implementation/commons/src/main/java/eu/efti/commons/utils/EftiSchemaUtils.java
+++ b/implementation/commons/src/main/java/eu/efti/commons/utils/EftiSchemaUtils.java
@@ -1,0 +1,19 @@
+package eu.efti.commons.utils;
+
+import org.w3c.dom.Document;
+
+public class EftiSchemaUtils {
+    public static Document mapCommonObjectToDoc(
+            SerializeUtils serializeUtils,
+            eu.efti.v1.consignment.common.SupplyChainConsignment consignmentCommon) {
+        return serializeUtils.mapJaxbObjectToDoc(consignmentCommon, eu.efti.v1.consignment.common.SupplyChainConsignment.class,
+                "consignment", "http://efti.eu/v1/consignment/common");
+    }
+
+    public static Document mapIdentifiersObjectToDoc(
+            SerializeUtils serializeUtils,
+            eu.efti.v1.consignment.identifier.SupplyChainConsignment consignmentIdentifiers) {
+        return serializeUtils.mapJaxbObjectToDoc(consignmentIdentifiers, eu.efti.v1.consignment.identifier.SupplyChainConsignment.class,
+                "consignment", "http://efti.eu/v1/consignment/identifier");
+    }
+}

--- a/implementation/commons/src/main/java/eu/efti/commons/utils/MappingException.java
+++ b/implementation/commons/src/main/java/eu/efti/commons/utils/MappingException.java
@@ -1,0 +1,7 @@
+package eu.efti.commons.utils;
+
+public class MappingException extends RuntimeException {
+    public MappingException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
+++ b/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
@@ -34,12 +34,6 @@ import java.util.Base64;
 @RequiredArgsConstructor
 @Slf4j
 public class SerializeUtils {
-    public static class MappingException extends RuntimeException {
-        public MappingException(String message, Exception cause) {
-            super(message, cause);
-        }
-    }
-
     private static final String ERROR_WHILE_WRITING_CONTENT = "error while writing content";
     private final ObjectMapper objectMapper;
 

--- a/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
+++ b/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
@@ -3,7 +3,6 @@ package eu.efti.commons.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import eu.efti.commons.exception.TechnicalException;
 import eu.efti.v1.edelivery.ObjectFactory;
 import jakarta.xml.bind.JAXBContext;
@@ -87,13 +86,17 @@ public class SerializeUtils {
     }
 
     public String mapDocToXmlString(Document doc) {
+        return mapDocToXmlString(doc, false);
+    }
+
+    public String mapDocToXmlString(Document doc, boolean prettyPrint) {
         try {
             var registry = DOMImplementationRegistry.newInstance();
             var domImplLS = (DOMImplementationLS) registry.getDOMImplementation("LS");
 
             var lsSerializer = domImplLS.createLSSerializer();
             var domConfig = lsSerializer.getDomConfig();
-            domConfig.setParameter("format-pretty-print", false);
+            domConfig.setParameter("format-pretty-print", prettyPrint);
 
             var byteArrayOutputStream = new ByteArrayOutputStream();
             var lsOutput = domImplLS.createLSOutput();
@@ -101,12 +104,11 @@ public class SerializeUtils {
             lsOutput.setByteStream(byteArrayOutputStream);
 
             lsSerializer.write(doc, lsOutput);
-            return byteArrayOutputStream.toString(Charsets.UTF_8);
+            return byteArrayOutputStream.toString(StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new TechnicalException("Could not serialize", e);
         }
     }
-
 
     @SuppressWarnings("unchecked")
     public <U> U mapXmlStringToJaxbObject(final String content) {

--- a/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
+++ b/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
@@ -3,19 +3,29 @@ package eu.efti.commons.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
 import eu.efti.commons.exception.TechnicalException;
 import eu.efti.v1.edelivery.ObjectFactory;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.UnmarshalException;
 import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.ValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
 
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -25,6 +35,11 @@ import java.util.Base64;
 @RequiredArgsConstructor
 @Slf4j
 public class SerializeUtils {
+    public static class MappingException extends RuntimeException {
+        public MappingException(String message, Exception cause) {
+            super(message, cause);
+        }
+    }
 
     private static final String ERROR_WHILE_WRITING_CONTENT = "error while writing content";
     private final ObjectMapper objectMapper;
@@ -49,6 +64,49 @@ public class SerializeUtils {
             throw new TechnicalException(ERROR_WHILE_WRITING_CONTENT, e);
         }
     }
+
+    /**
+     * Serialize a jakarta.xml.bind annotated pojo that may be missing the {@link jakarta.xml.bind.annotation.XmlRootElement}
+     * annotation. Will set root element name and namespace according to the given parameters.
+     */
+    public <U> Document mapJaxbObjectToDoc(U object, Class<U> clazz, String rootName, String rootNamespace) {
+        try {
+            var doc = documentBuilderFactory.newDocumentBuilder().newDocument();
+            JAXBContext.newInstance(clazz).createMarshaller().marshal(new JAXBElement<>(
+                            new QName(rootNamespace, rootName),
+                            clazz,
+                            null,
+                            object
+                    ),
+                    doc);
+
+            return doc;
+        } catch (Exception e) {
+            throw new TechnicalException("Could not serialize object", e);
+        }
+    }
+
+    public String mapDocToXmlString(Document doc) {
+        try {
+            var registry = DOMImplementationRegistry.newInstance();
+            var domImplLS = (DOMImplementationLS) registry.getDOMImplementation("LS");
+
+            var lsSerializer = domImplLS.createLSSerializer();
+            var domConfig = lsSerializer.getDomConfig();
+            domConfig.setParameter("format-pretty-print", false);
+
+            var byteArrayOutputStream = new ByteArrayOutputStream();
+            var lsOutput = domImplLS.createLSOutput();
+            lsOutput.setEncoding("UTF-8");
+            lsOutput.setByteStream(byteArrayOutputStream);
+
+            lsSerializer.write(doc, lsOutput);
+            return byteArrayOutputStream.toString(Charsets.UTF_8);
+        } catch (Exception e) {
+            throw new TechnicalException("Could not serialize", e);
+        }
+    }
+
 
     @SuppressWarnings("unchecked")
     public <U> U mapXmlStringToJaxbObject(final String content) {
@@ -85,6 +143,27 @@ public class SerializeUtils {
             throw new TechnicalException("Could not unmarshal", e);
         }
     }
+
+    /**
+     * Map to Jaxb object validating the xml against the given schema.
+     */
+    public <U> U mapXmlStringToJaxbObject(final String content, Class<U> clazz, Schema schema) throws MappingException {
+        try {
+            final JAXBContext jaxbContext = JAXBContext.newInstance(clazz);
+            final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            // Set schema to enable validation
+            unmarshaller.setSchema(schema);
+            final StreamSource source = new StreamSource(new ByteArrayInputStream(content.getBytes()));
+            final JAXBElement<U> jaxbElement = unmarshaller.unmarshal(source, clazz);
+            return jaxbElement.getValue();
+        } catch (final ValidationException | UnmarshalException e) {
+            throw new MappingException("Invalid content: " + e.getMessage(), e);
+        } catch (final JAXBException e) {
+            throw new TechnicalException("Could not unmarshal", e);
+        }
+    }
+
+    private static final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 
     public <T> String mapObjectToJsonString(final T content) {
         try {

--- a/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
+++ b/implementation/commons/src/main/java/eu/efti/commons/utils/SerializeUtils.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -69,6 +71,18 @@ public class SerializeUtils {
             return jaxbElement.getValue();
         } catch (final JAXBException e) {
             throw new TechnicalException(ERROR_WHILE_WRITING_CONTENT, e);
+        }
+    }
+
+    public <U> U mapXmlStringToJaxbObject(final String content, Class<U> clazz) {
+        try {
+            final JAXBContext jaxbContext = JAXBContext.newInstance(clazz);
+            final Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            final StreamSource source = new StreamSource(new ByteArrayInputStream(content.getBytes()));
+            final JAXBElement<U> jaxbElement = unmarshaller.unmarshal(source, clazz);
+            return jaxbElement.getValue();
+        } catch (final JAXBException e) {
+            throw new TechnicalException("Could not unmarshal", e);
         }
     }
 

--- a/implementation/gate/pom.xml
+++ b/implementation/gate/pom.xml
@@ -204,6 +204,26 @@
             <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Test Logs -->
         <dependency>

--- a/implementation/gate/pom.xml
+++ b/implementation/gate/pom.xml
@@ -85,6 +85,13 @@
         </dependency>
 
         <dependency>
+            <groupId>eu.efti</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/implementation/gate/pom.xml
+++ b/implementation/gate/pom.xml
@@ -224,6 +224,11 @@
             <artifactId>spring-boot-starter-webflux</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Test Logs -->
         <dependency>

--- a/implementation/gate/src/main/java/eu/efti/eftigate/config/WebConfig.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/config/WebConfig.java
@@ -1,0 +1,33 @@
+package eu.efti.eftigate.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+import java.util.Set;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private static class StringAsObjectHttpMessageConverter extends StringHttpMessageConverter {
+        private static final Set<Class<?>> support = Set.of(String.class, Object.class);
+
+        @Override
+        public boolean supports(@NonNull Class<?> clazz) {
+            return support.contains(clazz);
+        }
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        // We want to handle parameters of type Object and content type application/xml as plain strings so that we may
+        // do xml parsing explicitly in controller method. Let's add a pass-through converter for this combination as
+        // the first converter so that MappingJackson2XmlHttpMessageConverter is not used for conversion.
+        var stringAsObjectHttpMessageConverter = new StringAsObjectHttpMessageConverter();
+        stringAsObjectHttpMessageConverter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_XML));
+        converters.add(0, stringAsObjectHttpMessageConverter);
+    }
+}

--- a/implementation/gate/src/main/java/eu/efti/eftigate/config/security/RestApiRoles.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/config/security/RestApiRoles.java
@@ -1,0 +1,5 @@
+package eu.efti.eftigate.config.security;
+
+public class RestApiRoles {
+    public static final String ROLE_PLATFORM = "PLATFORM";
+}

--- a/implementation/gate/src/main/java/eu/efti/eftigate/config/security/SecurityConfig.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/config/security/SecurityConfig.java
@@ -1,22 +1,85 @@
 package eu.efti.eftigate.config.security;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+
+import java.util.Set;
 
 @Configuration
 @EnableMethodSecurity(securedEnabled = true)
 @EnableWebSecurity
 public class SecurityConfig {
+    private record Principal(String username, String role) {}
+
+    private static class EftiApiPreAuthenticatedUserHeaderFilter extends AbstractPreAuthenticatedProcessingFilter {
+        private static final Logger logger = LoggerFactory.getLogger(EftiApiPreAuthenticatedUserHeaderFilter.class);
+
+        @Override
+        protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+            var userId = parseHeader(request, "X-Pre-Authenticated-User-Id");
+            var role = parseHeader(request, "X-Pre-Authenticated-User-Role");
+
+            if (userId != null && role != null) {
+                return new Principal(userId, role);
+            } else {
+                return null;
+            }
+        }
+
+        private String parseHeader(HttpServletRequest request, String header) {
+            var value = request.getHeader(header);
+            if (logger.isDebugEnabled()) {
+                logger.debug("{}: {}", header, value);
+            }
+            return StringUtils.defaultIfBlank(value, null);
+        }
+
+        @Override
+        protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+            return "not-applicable";
+        }
+    }
+
+    private static PreAuthenticatedAuthenticationProvider createRestApiPreAuthenticatedAuthenticationProvider() {
+        var userDetailsService = new AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken>() {
+            @Override
+            public UserDetails loadUserDetails(PreAuthenticatedAuthenticationToken token) throws UsernameNotFoundException {
+                var principal = (Principal) token.getPrincipal();
+                // Note: spring security expects authority names (roles) to have prefix "ROLE_".
+                return new User(principal.username, "", Set.of(new SimpleGrantedAuthority("ROLE_" + principal.role)));
+            }
+        };
+
+        var provider = new PreAuthenticatedAuthenticationProvider();
+        provider.setPreAuthenticatedUserDetailsService(userDetailsService);
+
+        return provider;
+    }
+
     @Bean
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
         return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
@@ -31,7 +94,31 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(final HttpSecurity http, final JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
+    @Order(1)
+    public SecurityFilterChain platformApiFilterChain(final HttpSecurity http) throws Exception {
+        var eftiApiPreAuthenticatedUserHeaderFilter = new EftiApiPreAuthenticatedUserHeaderFilter();
+        eftiApiPreAuthenticatedUserHeaderFilter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
+        eftiApiPreAuthenticatedUserHeaderFilter.setAuthenticationManager(new ProviderManager(createRestApiPreAuthenticatedAuthenticationProvider()));
+
+        http.csrf(AbstractHttpConfigurer::disable)
+                .securityMatcher("/api/platform/**")
+                .addFilter(eftiApiPreAuthenticatedUserHeaderFilter)
+                .sessionManagement(
+                        management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                                .sessionFixation().changeSessionId()
+                )
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/platform/**").hasRole(RestApiRoles.ROLE_PLATFORM)
+                        .anyRequest().denyAll()
+                )
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain defaultFilterChain(final HttpSecurity http, final JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(
                         management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/implementation/gate/src/main/java/eu/efti/eftigate/controller/PlatformApiContextResolver.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/controller/PlatformApiContextResolver.java
@@ -1,0 +1,37 @@
+package eu.efti.eftigate.controller;
+
+import eu.efti.eftigate.config.security.RestApiRoles;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.stream.Collectors;
+
+public class PlatformApiContextResolver {
+    public record PlatformContext(String platformId, String role) {
+    }
+
+    /**
+     * Get details of the authenticated platform user from {@link org.springframework.security.core.context.SecurityContext}.
+     *
+     * @return details of the user
+     * @throws IllegalStateException if no authenticated platform user was found
+     */
+    public static PlatformContext getPlatformContextOrFail() {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new IllegalStateException("No authentication found");
+        }
+
+        var user = (User) authentication.getPrincipal();
+
+        var expectedRoleName = "ROLE_" + RestApiRoles.ROLE_PLATFORM;
+        var hasRole = user.getAuthorities().stream().anyMatch(gr -> expectedRoleName.equals(gr.getAuthority()));
+        if (hasRole) {
+            return new PlatformContext(user.getUsername(), RestApiRoles.ROLE_PLATFORM);
+        } else {
+            throw new IllegalStateException("Current user does not have role " + expectedRoleName + " but " +
+                    user.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(", ")));
+        }
+    }
+}

--- a/implementation/gate/src/main/java/eu/efti/eftigate/controller/PlatformApiController.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/controller/PlatformApiController.java
@@ -2,22 +2,19 @@ package eu.efti.eftigate.controller;
 
 import eu.efti.eftigate.controller.api.platform.V0Api;
 import eu.efti.eftigate.dto.GetWhoami200Response;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/platform")
 @Tag(name = "Platform API", description = "REST API for the platforms")
 public class PlatformApiController implements V0Api {
-
     @Override
     public ResponseEntity<GetWhoami200Response> getWhoami() {
-        return null;
+        var ctx = PlatformApiContextResolver.getPlatformContextOrFail();
+        return ResponseEntity.ok(new GetWhoami200Response(ctx.platformId(), ctx.role()));
     }
 
     @Override

--- a/implementation/gate/src/main/java/eu/efti/eftigate/controller/PlatformApiController.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/controller/PlatformApiController.java
@@ -1,8 +1,17 @@
 package eu.efti.eftigate.controller;
 
+import eu.efti.commons.dto.SaveIdentifiersRequestWrapper;
+import eu.efti.commons.utils.SerializeUtils;
 import eu.efti.eftigate.controller.api.platform.V0Api;
 import eu.efti.eftigate.dto.GetWhoami200Response;
+import eu.efti.eftigate.service.request.ValidationService;
+import eu.efti.identifiersregistry.service.IdentifiersService;
+import eu.efti.v1.consignment.identifier.SupplyChainConsignment;
+import eu.efti.v1.edelivery.SaveIdentifiersRequest;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,7 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/platform")
 @Tag(name = "Platform API", description = "REST API for the platforms")
+@AllArgsConstructor
 public class PlatformApiController implements V0Api {
+    private IdentifiersService identifiersService;
+
+    private SerializeUtils serializeUtils;
+
+    private ValidationService validationService;
+
     @Override
     public ResponseEntity<GetWhoami200Response> getWhoami() {
         var ctx = PlatformApiContextResolver.getPlatformContextOrFail();
@@ -19,6 +35,23 @@ public class PlatformApiController implements V0Api {
 
     @Override
     public ResponseEntity<Void> putConsignmentIdentifiers(String datasetId, Object body) {
-        return null;
+        var ctx = PlatformApiContextResolver.getPlatformContextOrFail();
+
+        var xml = (String) body;
+        var validationError = validationService.isXmlValid(xml);
+        if (validationError.isPresent()) {
+            var problemDetail = org.springframework.http.ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+            problemDetail.setDetail(validationError.get());
+            return ResponseEntity.of(problemDetail).headers(h -> h.setContentType(MediaType.APPLICATION_PROBLEM_XML)).build();
+        } else {
+            SupplyChainConsignment consignment = serializeUtils.mapXmlStringToJaxbObject(xml, SupplyChainConsignment.class);
+
+            SaveIdentifiersRequest saveIdentifiersRequest = new SaveIdentifiersRequest();
+            saveIdentifiersRequest.setDatasetId(datasetId);
+            saveIdentifiersRequest.setConsignment(consignment);
+            identifiersService.createOrUpdate(new SaveIdentifiersRequestWrapper(ctx.platformId(), saveIdentifiersRequest));
+
+            return ResponseEntity.ok().build();
+        }
     }
 }

--- a/implementation/gate/src/test/java/eu/efti/eftigate/integration/ApiSecurityIT.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/integration/ApiSecurityIT.java
@@ -1,0 +1,55 @@
+package eu.efti.eftigate.integration;
+
+import eu.efti.eftigate.testsupport.RestIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ApiSecurityIT extends RestIntegrationTest {
+    @Test
+    public void nonPreAuthenticatedPlatformShouldNotHaveAccessToPlatformApi() {
+        var caller = restApiCallerFactory.createUnauthenticated();
+        var res = caller.get("/api/platform/v0/whoami", String.class);
+        assertAll(
+                () -> assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus()),
+                () -> assertNull(res.getResponseBody())
+        );
+    }
+
+    @Test
+    public void preAuthenticatedPlatformShouldHaveAccessToPlatformApi() {
+        var somePlatformId = "some-platform";
+        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi(somePlatformId);
+        var res = caller.get("/api/platform/v0/whoami", String.class);
+        assertAll(
+                () -> assertEquals(HttpStatus.OK, res.getStatus()),
+                () -> assertEquals(
+                        "<whoamiResponse><appId>" + somePlatformId + "</appId><role>PLATFORM</role></whoamiResponse>",
+                        res.getResponseBody())
+        );
+    }
+
+    @Test
+    public void preAuthenticatedWithNonPlatformRoleShouldNotHaveAccessToPlatformApi() {
+        var caller = restApiCallerFactory.createAuthenticatedWithRole("some-platform", "some-role");
+        var res = caller.get("/api/platform/v0/whoami", String.class);
+        assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus());
+    }
+
+    @Test
+    public void preAuthenticatedPlatformShouldNotHaveAccessToApiRoot() {
+        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi("some-platform");
+        var res = caller.get("/api", Object.class);
+        assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus());
+    }
+
+    @Test
+    public void preAuthenticatedPlatformShouldNotHaveAccessToWSApi() {
+        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi("some-platform");
+        var res = caller.get("/ws", Object.class);
+        assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus());
+    }
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/integration/ApiSecurityIT.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/integration/ApiSecurityIT.java
@@ -4,7 +4,7 @@ import eu.efti.eftigate.testsupport.RestIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import static eu.efti.eftigate.testsupport.TestData.randomIdentifier;
+import static eu.efti.testsupport.TestData.randomIdentifier;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/implementation/gate/src/test/java/eu/efti/eftigate/integration/ApiSecurityIT.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/integration/ApiSecurityIT.java
@@ -4,6 +4,7 @@ import eu.efti.eftigate.testsupport.RestIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import static eu.efti.eftigate.testsupport.TestData.randomIdentifier;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -21,34 +22,34 @@ public class ApiSecurityIT extends RestIntegrationTest {
 
     @Test
     public void preAuthenticatedPlatformShouldHaveAccessToPlatformApi() {
-        var somePlatformId = "some-platform";
-        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi(somePlatformId);
+        var platformId = randomIdentifier();
+        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi(platformId);
         var res = caller.get("/api/platform/v0/whoami", String.class);
         assertAll(
                 () -> assertEquals(HttpStatus.OK, res.getStatus()),
                 () -> assertEquals(
-                        "<whoamiResponse><appId>" + somePlatformId + "</appId><role>PLATFORM</role></whoamiResponse>",
+                        "<whoamiResponse><appId>" + platformId + "</appId><role>PLATFORM</role></whoamiResponse>",
                         res.getResponseBody())
         );
     }
 
     @Test
     public void preAuthenticatedWithNonPlatformRoleShouldNotHaveAccessToPlatformApi() {
-        var caller = restApiCallerFactory.createAuthenticatedWithRole("some-platform", "some-role");
+        var caller = restApiCallerFactory.createAuthenticatedWithRole(randomIdentifier(), randomIdentifier());
         var res = caller.get("/api/platform/v0/whoami", String.class);
         assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus());
     }
 
     @Test
     public void preAuthenticatedPlatformShouldNotHaveAccessToApiRoot() {
-        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi("some-platform");
+        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi(randomIdentifier());
         var res = caller.get("/api", Object.class);
         assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus());
     }
 
     @Test
     public void preAuthenticatedPlatformShouldNotHaveAccessToWSApi() {
-        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi("some-platform");
+        var caller = restApiCallerFactory.createAuthenticatedForPlatformApi(randomIdentifier());
         var res = caller.get("/ws", Object.class);
         assertEquals(HttpStatus.UNAUTHORIZED, res.getStatus());
     }

--- a/implementation/gate/src/test/java/eu/efti/eftigate/integration/PlatformApiIT.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/integration/PlatformApiIT.java
@@ -1,0 +1,204 @@
+package eu.efti.eftigate.integration;
+
+import eu.efti.commons.utils.EftiSchemaUtils;
+import eu.efti.commons.utils.SerializeUtils;
+import eu.efti.eftigate.testsupport.RestIntegrationTest;
+import eu.efti.identifiersregistry.IdentifiersMapper;
+import eu.efti.identifiersregistry.repository.IdentifiersRepository;
+import eu.efti.v1.codes.CountryCode;
+import eu.efti.v1.codes.TransportEquipmentCategoryCode;
+import eu.efti.v1.consignment.identifier.LogisticsTransportEquipment;
+import eu.efti.v1.consignment.identifier.LogisticsTransportMeans;
+import eu.efti.v1.consignment.identifier.LogisticsTransportMovement;
+import eu.efti.v1.consignment.identifier.SupplyChainConsignment;
+import eu.efti.v1.consignment.identifier.TradeCountry;
+import eu.efti.v1.consignment.identifier.TransportEvent;
+import eu.efti.v1.edelivery.Consignment;
+import eu.efti.v1.edelivery.UIL;
+import eu.efti.v1.types.DateTime;
+import eu.efti.v1.types.Identifier17;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class PlatformApiIT extends RestIntegrationTest {
+    private static final String GATE_ID = "gate-it";
+
+    @Autowired
+    private SerializeUtils serializeUtils;
+
+    @Autowired
+    private IdentifiersRepository identifiersRepository;
+
+    @Autowired
+    private IdentifiersMapper identifiersMapper;
+
+    @Test
+    public void whoamiShouldReturnCallingPlatformId() {
+        // Arrange
+        var somePlatformId = "some-platform";
+
+        // Act
+        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(somePlatformId).get("/api/platform/v0/whoami", String.class);
+
+        // Assert
+        assertAll(
+                () -> assertEquals(HttpStatus.OK, res.getStatus()),
+                () -> assertEquals(
+                        "<whoamiResponse><appId>" + somePlatformId + "</appId><role>PLATFORM</role></whoamiResponse>",
+                        res.getResponseBody())
+        );
+    }
+
+    @Test
+    public void invalidIdentifiersShouldBeRejected() {
+        // Arrange
+        var somePlatformId = "some-platform";
+        var datasetId = UUID.randomUUID().toString();
+
+        // Act
+        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(somePlatformId)
+                .put("/api/platform/v0/consignments/" + datasetId, "<some-invalid-element/>", MediaType.APPLICATION_XML, Void.class);
+
+        // Assert
+        assertEquals(HttpStatus.BAD_REQUEST, res.getStatus());
+    }
+
+    @Test
+    public void validIdentifiersShouldBeAddedToGateDatabase() {
+        // Arrange
+        var platformId = "some-platform";
+        var platformConsignment = newRandomSupplyChainConsignment();
+        var platformXml = serializeUtils.mapDocToXmlString(EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, platformConsignment), true);
+        var datasetId = UUID.randomUUID().toString();
+
+        // Act
+        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(platformId)
+                .put("/api/platform/v0/consignments/" + datasetId, platformXml, MediaType.APPLICATION_XML, Void.class);
+
+        // Assert
+        var gateConsignment = toConsignmentIdentifier(identifiersRepository.findByUil(GATE_ID, datasetId, platformId).get());
+        var gateXml = serializeUtils.mapDocToXmlString(EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, gateConsignment), true);
+
+        assertAll(
+                () -> assertEquals(HttpStatus.OK, res.getStatus()),
+                () -> assertEquals(platformXml, gateXml)
+        );
+    }
+
+    @Test
+    public void validIdentifiersShouldBeUpdatedToGateDatabase() {
+        // Arrange
+        var platformId = "some-platform";
+        var datasetId = UUID.randomUUID().toString();
+        identifiersRepository.save(toEntity(GATE_ID, platformId, datasetId, newRandomSupplyChainConsignment()));
+        var originalConsignment = toConsignmentIdentifier(identifiersRepository.findByUil(GATE_ID, datasetId, platformId).get());
+
+        // Act
+        var updatedPlatformXml = serializeUtils.mapDocToXmlString(EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, newRandomSupplyChainConsignment()), true);
+        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(platformId)
+                .put("/api/platform/v0/consignments/" + datasetId, updatedPlatformXml, MediaType.APPLICATION_XML, Void.class);
+
+        // Assert
+        var gateConsignment = toConsignmentIdentifier(identifiersRepository.findByUil(GATE_ID, datasetId, platformId).get());
+        var gateXml = serializeUtils.mapDocToXmlString(EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, gateConsignment), true);
+
+        assertAll(
+                () -> assertEquals(HttpStatus.OK, res.getStatus()),
+                () -> assertEquals(updatedPlatformXml, gateXml),
+                () -> assertNotEquals(updatedPlatformXml, serializeUtils.mapDocToXmlString(EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, originalConsignment), true))
+        );
+    }
+
+    private eu.efti.identifiersregistry.entity.Consignment toEntity(String gateId, String platformId, String datasetId, SupplyChainConsignment consignment) {
+        var ce = new Consignment();
+
+        var uil = new UIL();
+        uil.setGateId(gateId);
+        uil.setPlatformId(platformId);
+        uil.setDatasetId(datasetId);
+
+        ce.setUil(uil);
+        ce.setDeliveryEvent(consignment.getDeliveryEvent());
+        ce.setCarrierAcceptanceDateTime(consignment.getCarrierAcceptanceDateTime());
+        ce.getUsedTransportEquipment().addAll(consignment.getUsedTransportEquipment());
+        ce.getMainCarriageTransportMovement().addAll(consignment.getMainCarriageTransportMovement());
+
+        return identifiersMapper.eDeliveryToEntity(ce);
+    }
+
+    private SupplyChainConsignment toConsignmentIdentifier(eu.efti.identifiersregistry.entity.Consignment entity) {
+        eu.efti.v1.edelivery.Consignment edeliveryConsignment = identifiersMapper.entityToEdelivery(entity);
+
+        var ci = new SupplyChainConsignment();
+        ci.setDeliveryEvent(edeliveryConsignment.getDeliveryEvent());
+        ci.setCarrierAcceptanceDateTime(edeliveryConsignment.getCarrierAcceptanceDateTime());
+        ci.getMainCarriageTransportMovement().addAll(edeliveryConsignment.getMainCarriageTransportMovement());
+        ci.getUsedTransportEquipment().addAll(edeliveryConsignment.getUsedTransportEquipment());
+
+        return ci;
+    }
+
+    private static SupplyChainConsignment newRandomSupplyChainConsignment() {
+        SupplyChainConsignment c = new SupplyChainConsignment();
+
+        c.setCarrierAcceptanceDateTime(newDateTime(Instant.now().plus(-1, ChronoUnit.DAYS)));
+
+        c.setDeliveryEvent(new TransportEvent());
+        c.getDeliveryEvent().setActualOccurrenceDateTime(newDateTime(Instant.now().plus(1, ChronoUnit.DAYS)));
+
+        var ltmo = new LogisticsTransportMovement();
+        ltmo.setDangerousGoodsIndicator(new Random().nextBoolean());
+        ltmo.setModeCode("1");
+        ltmo.setUsedTransportMeans(new LogisticsTransportMeans());
+        ltmo.getUsedTransportMeans().setId(newIdentifier17(RandomStringUtils.randomAlphanumeric(8)));
+        ltmo.getUsedTransportMeans().setRegistrationCountry(newTradeCountry(CountryCode.AD));
+        c.getMainCarriageTransportMovement().add(ltmo);
+
+        var lte = new LogisticsTransportEquipment();
+        lte.setId(newIdentifier17(RandomStringUtils.randomAlphanumeric(8)));
+        lte.setCategoryCode(TransportEquipmentCategoryCode.AE);
+        lte.setRegistrationCountry(newTradeCountry(CountryCode.AE));
+        lte.setSequenceNumber(BigInteger.ONE);
+        c.getUsedTransportEquipment().add(lte);
+
+        return c;
+    }
+
+    private static TradeCountry newTradeCountry(CountryCode countryCode) {
+        TradeCountry tc = new TradeCountry();
+        tc.setCode(countryCode);
+        return tc;
+    }
+
+    private static Identifier17 newIdentifier17(String idValue) {
+        Identifier17 id = new Identifier17();
+        id.setValue(idValue);
+        return id;
+    }
+
+    private static DateTime newDateTime(Instant instant) {
+        var dateTime = new DateTime();
+        dateTime.setFormatId("205");
+        dateTime.setValue(OffsetDateTime
+                .ofInstant(instant.truncatedTo(ChronoUnit.MINUTES), ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmZ")));
+        return dateTime;
+    }
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/integration/PlatformApiIT.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/integration/PlatformApiIT.java
@@ -17,7 +17,6 @@ import eu.efti.v1.edelivery.Consignment;
 import eu.efti.v1.edelivery.UIL;
 import eu.efti.v1.types.DateTime;
 import eu.efti.v1.types.Identifier17;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -29,9 +28,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Random;
 import java.util.UUID;
 
+import static eu.efti.eftigate.testsupport.TestData.random;
+import static eu.efti.eftigate.testsupport.TestData.randomBoolean;
+import static eu.efti.eftigate.testsupport.TestData.randomFutureInstant;
+import static eu.efti.eftigate.testsupport.TestData.randomIdentifier;
+import static eu.efti.eftigate.testsupport.TestData.randomPastInstant;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -52,16 +55,16 @@ public class PlatformApiIT extends RestIntegrationTest {
     @Test
     public void whoamiShouldReturnCallingPlatformId() {
         // Arrange
-        var somePlatformId = "some-platform";
+        var platformId = randomIdentifier();
 
         // Act
-        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(somePlatformId).get("/api/platform/v0/whoami", String.class);
+        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(platformId).get("/api/platform/v0/whoami", String.class);
 
         // Assert
         assertAll(
                 () -> assertEquals(HttpStatus.OK, res.getStatus()),
                 () -> assertEquals(
-                        "<whoamiResponse><appId>" + somePlatformId + "</appId><role>PLATFORM</role></whoamiResponse>",
+                        "<whoamiResponse><appId>" + platformId + "</appId><role>PLATFORM</role></whoamiResponse>",
                         res.getResponseBody())
         );
     }
@@ -69,11 +72,11 @@ public class PlatformApiIT extends RestIntegrationTest {
     @Test
     public void invalidIdentifiersShouldBeRejected() {
         // Arrange
-        var somePlatformId = "some-platform";
+        var platformId = randomIdentifier();
         var datasetId = UUID.randomUUID().toString();
 
         // Act
-        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(somePlatformId)
+        var res = restApiCallerFactory.createAuthenticatedForPlatformApi(platformId)
                 .put("/api/platform/v0/consignments/" + datasetId, "<some-invalid-element/>", MediaType.APPLICATION_XML, Void.class);
 
         // Assert
@@ -83,7 +86,7 @@ public class PlatformApiIT extends RestIntegrationTest {
     @Test
     public void validIdentifiersShouldBeAddedToGateDatabase() {
         // Arrange
-        var platformId = "some-platform";
+        var platformId = randomIdentifier();
         var platformConsignment = newRandomSupplyChainConsignment();
         var platformXml = serializeUtils.mapDocToXmlString(EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, platformConsignment), true);
         var datasetId = UUID.randomUUID().toString();
@@ -105,7 +108,7 @@ public class PlatformApiIT extends RestIntegrationTest {
     @Test
     public void validIdentifiersShouldBeUpdatedToGateDatabase() {
         // Arrange
-        var platformId = "some-platform";
+        var platformId = randomIdentifier();
         var datasetId = UUID.randomUUID().toString();
         identifiersRepository.save(toEntity(GATE_ID, platformId, datasetId, newRandomSupplyChainConsignment()));
         var originalConsignment = toConsignmentIdentifier(identifiersRepository.findByUil(GATE_ID, datasetId, platformId).get());
@@ -158,38 +161,38 @@ public class PlatformApiIT extends RestIntegrationTest {
     private static SupplyChainConsignment newRandomSupplyChainConsignment() {
         SupplyChainConsignment c = new SupplyChainConsignment();
 
-        c.setCarrierAcceptanceDateTime(newDateTime(Instant.now().plus(-1, ChronoUnit.DAYS)));
+        c.setCarrierAcceptanceDateTime(newDateTime(randomPastInstant()));
 
         c.setDeliveryEvent(new TransportEvent());
-        c.getDeliveryEvent().setActualOccurrenceDateTime(newDateTime(Instant.now().plus(1, ChronoUnit.DAYS)));
+        c.getDeliveryEvent().setActualOccurrenceDateTime(newDateTime(randomFutureInstant()));
 
         var ltmo = new LogisticsTransportMovement();
-        ltmo.setDangerousGoodsIndicator(new Random().nextBoolean());
-        ltmo.setModeCode("1");
+        ltmo.setDangerousGoodsIndicator(randomBoolean());
+        ltmo.setModeCode(random("1", "2", "3", "4"));
         ltmo.setUsedTransportMeans(new LogisticsTransportMeans());
-        ltmo.getUsedTransportMeans().setId(newIdentifier17(RandomStringUtils.randomAlphanumeric(8)));
-        ltmo.getUsedTransportMeans().setRegistrationCountry(newTradeCountry(CountryCode.AD));
+        ltmo.getUsedTransportMeans().setId(newIdentifier17());
+        ltmo.getUsedTransportMeans().setRegistrationCountry(newTradeCountry());
         c.getMainCarriageTransportMovement().add(ltmo);
 
         var lte = new LogisticsTransportEquipment();
-        lte.setId(newIdentifier17(RandomStringUtils.randomAlphanumeric(8)));
-        lte.setCategoryCode(TransportEquipmentCategoryCode.AE);
-        lte.setRegistrationCountry(newTradeCountry(CountryCode.AE));
+        lte.setId(newIdentifier17());
+        lte.setCategoryCode(random(TransportEquipmentCategoryCode.class));
+        lte.setRegistrationCountry(newTradeCountry());
         lte.setSequenceNumber(BigInteger.ONE);
         c.getUsedTransportEquipment().add(lte);
 
         return c;
     }
 
-    private static TradeCountry newTradeCountry(CountryCode countryCode) {
+    private static TradeCountry newTradeCountry() {
         TradeCountry tc = new TradeCountry();
-        tc.setCode(countryCode);
+        tc.setCode(random(CountryCode.class));
         return tc;
     }
 
-    private static Identifier17 newIdentifier17(String idValue) {
+    private static Identifier17 newIdentifier17() {
         Identifier17 id = new Identifier17();
-        id.setValue(idValue);
+        id.setValue(randomIdentifier());
         return id;
     }
 

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/IntegrationTest.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/IntegrationTest.java
@@ -1,0 +1,20 @@
+package eu.efti.eftigate.testsupport;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("it")
+@TestPropertySource(locations = "classpath:application-it.yml")
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+@Import(TestConfig.class)
+public class IntegrationTest {
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/IntegrationTest.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/IntegrationTest.java
@@ -1,5 +1,7 @@
 package eu.efti.eftigate.testsupport;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,4 +19,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
 @Import(TestConfig.class)
 public class IntegrationTest {
+    @Autowired
+    private TestConfig.DbCleaner dbCleaner;
+
+    @BeforeEach
+    void clearDbTables() {
+        dbCleaner.clearTables();
+    }
 }

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/RestApiCallerFactory.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/RestApiCallerFactory.java
@@ -6,10 +6,12 @@ import io.netty.handler.logging.LogLevel;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.logging.AdvancedByteBufFormat;
 
@@ -20,8 +22,12 @@ import java.util.function.Consumer;
 @Component
 public class RestApiCallerFactory {
     public record RestApiCaller(WebTestClient webTestClient) {
-        public <T> EntityExchangeResult<T> get(String url, Class<T> clazz) {
-            return webTestClient.get().uri(url).exchange().expectBody(clazz).returnResult();
+        public <O> EntityExchangeResult<O> get(String url, Class<O> responseType) {
+            return webTestClient.get().uri(url).exchange().expectBody(responseType).returnResult();
+        }
+
+        public <I, O> EntityExchangeResult<O> put(String url, I body, MediaType contentType, Class<O> responseType) {
+            return webTestClient.put().uri(url).contentType(contentType).body(BodyInserters.fromValue(body)).exchange().expectBody(responseType).returnResult();
         }
     }
 
@@ -29,7 +35,8 @@ public class RestApiCallerFactory {
     private int port;
 
     public RestApiCaller createUnauthenticated() {
-        return getRestApiCaller(h -> {});
+        return getRestApiCaller(h -> {
+        });
     }
 
     public RestApiCaller createAuthenticatedForPlatformApi(String platformId) {

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/RestApiCallerFactory.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/RestApiCallerFactory.java
@@ -1,0 +1,60 @@
+package eu.efti.eftigate.testsupport;
+
+import eu.efti.eftigate.config.security.RestApiRoles;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.logging.LogLevel;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+import java.util.function.Consumer;
+
+// Note: lazy initialization to ensure @LocalServerPort is initialized before we read it
+@Lazy
+@Component
+public class RestApiCallerFactory {
+    public record RestApiCaller(WebTestClient webTestClient) {
+        public <T> EntityExchangeResult<T> get(String url, Class<T> clazz) {
+            return webTestClient.get().uri(url).exchange().expectBody(clazz).returnResult();
+        }
+    }
+
+    @LocalServerPort
+    private int port;
+
+    public RestApiCaller createUnauthenticated() {
+        return getRestApiCaller(h -> {});
+    }
+
+    public RestApiCaller createAuthenticatedForPlatformApi(String platformId) {
+        return createAuthenticatedWithRole(platformId, RestApiRoles.ROLE_PLATFORM);
+    }
+
+    public RestApiCaller createAuthenticatedWithRole(String platformId, String role) {
+        return getRestApiCaller(h -> h
+                .set("X-Pre-Authenticated-User-Id", platformId)
+                .set("X-Pre-Authenticated-User-Role", role));
+    }
+
+    private @NotNull RestApiCaller getRestApiCaller(Consumer<HttpHeaders> headersCustomizer) {
+        var httpClient = HttpClient.create()
+                .wiretap(
+                        RestApiCaller.class.getCanonicalName(),
+                        LogLevel.INFO,
+                        AdvancedByteBufFormat.TEXTUAL
+                )
+                .headers(headersCustomizer);
+
+        var testClient = WebTestClient.bindToServer(new ReactorClientHttpConnector(httpClient))
+                .baseUrl("http://localhost:" + port)
+                .build();
+
+        return new RestApiCaller(testClient);
+    }
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/RestIntegrationTest.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/RestIntegrationTest.java
@@ -1,0 +1,12 @@
+package eu.efti.eftigate.testsupport;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+abstract public class RestIntegrationTest extends IntegrationTest {
+    @Autowired
+    protected RestApiCallerFactory restApiCallerFactory;
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestConfig.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestConfig.java
@@ -1,0 +1,7 @@
+package eu.efti.eftigate.testsupport;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+public class TestConfig {
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestConfig.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestConfig.java
@@ -1,7 +1,107 @@
 package eu.efti.eftigate.testsupport;
 
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 @TestConfiguration
 public class TestConfig {
+    @Slf4j
+    public static class DbCleaner {
+        private final SQLRunner sqlRunner;
+
+        private final List<String> tablesToClear;
+
+        private static final List<Predicate<String>> EXCLUSIONS = List.of(
+                tableName -> tableName.endsWith("databasechangelog"),
+                tableName -> tableName.endsWith("databasechangeloglock"),
+                tableName -> tableName.endsWith("shedlock")
+        );
+
+        private DbCleaner(SQLRunner sqlRunner) {
+            this.sqlRunner = sqlRunner;
+            this.tablesToClear = sqlRunner.getDatabaseTableNames()
+                    .stream()
+                    .filter(tableName -> EXCLUSIONS.stream().noneMatch(exclusion -> exclusion.test(tableName)))
+                    .toList();
+        }
+
+        public void clearTables() {
+            sqlRunner.executeStatements(List.of("TRUNCATE TABLE " + String.join(", ", tablesToClear) + ";"));
+        }
+    }
+
+    @Slf4j
+    @AllArgsConstructor
+    private static class SQLRunner {
+        private JdbcTemplate template;
+
+        private DatabaseMetaData metaData;
+
+        @Transactional
+        void executeStatements(List<String> statements) {
+            log.trace("Executing statements: {}", statements);
+            statements.forEach(template::execute);
+        }
+
+        @Transactional
+        List<String> getDatabaseTableNames() {
+            try {
+                try (var rs = metaData.getTables(null, null, "%", new String[]{"TABLE"})) {
+                    var result = new ArrayList<String>();
+                    while (rs.next()) {
+                        var tableName = rs.getString("TABLE_NAME");
+                        var schemaName = rs.getString("TABLE_SCHEM");
+                        result.add(schemaName + "." + tableName);
+                    }
+                    return result;
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Bean
+    public DbCleaner getDbCleaner(DataSource controlDataSource, DataSource identifiersDataSource) {
+        var url1 = getUrl(controlDataSource);
+        var url2 = getUrl(identifiersDataSource);
+        if (!url1.equals(url2)) {
+            throw new IllegalStateException(String.format(
+                    "There are two data sources with different urls (\"%s\" and \"%s\" but this implementation only knows how to clean one of them", url1, url2));
+        }
+        return new DbCleaner(createSqlRunner(identifiersDataSource));
+    }
+
+    private SQLRunner createSqlRunner(DataSource dataSource) {
+        var template = new JdbcTemplate(dataSource);
+        var metaData = getMeta(dataSource);
+        return new SQLRunner(template, metaData);
+    }
+
+    private static String getUrl(DataSource dataSource) {
+        try {
+            return dataSource.getConnection().getMetaData().getURL();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static DatabaseMetaData getMeta(DataSource dataSource) {
+        try {
+            return dataSource.getConnection().getMetaData();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestData.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestData.java
@@ -1,0 +1,67 @@
+package eu.efti.eftigate.testsupport;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Random;
+
+/**
+ * Utility functions for creating reproducible pseudo-random test data. Before each test, reset the generator
+ * with {@link #resetSeed()} to make test cases reproducible.
+ */
+public class TestData {
+    /**
+     * Random seed used for random generator. Replace with a constant value if you need to debug tests that break when
+     * a specific seed value is used.
+     */
+    private static final long defaultSeed = LocalDate.now().getDayOfMonth() % 4;
+
+    private static final Random random = new Random();
+
+    private static final char[] ALPHANUMERICAL_CHARS = {
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
+    };
+
+    public static long resetSeed() {
+        random.setSeed(defaultSeed);
+        return defaultSeed;
+    }
+
+    public static <T extends Enum<T>> T random(Class<T> enumClass) {
+        var choices = enumClass.getEnumConstants();
+        return randomChoice(choices);
+    }
+
+    @SafeVarargs
+    public static <T> T random(T... choices) {
+        return randomChoice(choices);
+    }
+
+    public static boolean randomBoolean() {
+        return random.nextBoolean();
+    }
+
+    public static Instant randomFutureInstant() {
+        return Instant.now().truncatedTo(ChronoUnit.DAYS).plus(randomLong(30), ChronoUnit.DAYS).plus(randomLong(23), ChronoUnit.HOURS);
+    }
+
+    public static String randomIdentifier() {
+        return RandomStringUtils.random(4, 0, ALPHANUMERICAL_CHARS.length, true, true, ALPHANUMERICAL_CHARS, random);
+    }
+
+    public static long randomLong(long endExclusive) {
+        return random.nextLong(0, endExclusive);
+    }
+
+    public static Instant randomPastInstant() {
+        return Instant.now().truncatedTo(ChronoUnit.DAYS).plus(-randomLong(30), ChronoUnit.DAYS).plus(-randomLong(23), ChronoUnit.HOURS);
+    }
+
+    private static <T> T randomChoice(T[] choices) {
+        return choices[random.nextInt(0, choices.length - 1)];
+    }
+}

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestDataRandomSeedResettingTestExecutionListener.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestDataRandomSeedResettingTestExecutionListener.java
@@ -1,5 +1,6 @@
 package eu.efti.eftigate.testsupport;
 
+import eu.efti.testsupport.TestData;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.launcher.TestExecutionListener;

--- a/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestDataRandomSeedResettingTestExecutionListener.java
+++ b/implementation/gate/src/test/java/eu/efti/eftigate/testsupport/TestDataRandomSeedResettingTestExecutionListener.java
@@ -1,0 +1,17 @@
+package eu.efti.eftigate.testsupport;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+@Slf4j
+public class TestDataRandomSeedResettingTestExecutionListener implements TestExecutionListener {
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        if (TestDescriptor.Type.TEST.equals(testIdentifier.getType())) {
+            var seed = TestData.resetSeed();
+            log.trace("Reset random seed to {}", seed);
+        }
+    }
+}

--- a/implementation/gate/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/implementation/gate/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+eu.efti.eftigate.testsupport.TestDataRandomSeedResettingTestExecutionListener

--- a/implementation/gate/src/test/resources/application-it.yml
+++ b/implementation/gate/src/test/resources/application-it.yml
@@ -2,20 +2,24 @@ spring:
   datasource:
     control:
       driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-      jdbc-url: jdbc:tc:postgresql:15.4:///gate-test?user=efti&TC_DAEMON=true
+      jdbc-url: jdbc:tc:postgresql:15.4:///test?user=efti&TC_DAEMON=true&TC_INITSCRIPT=sql/init-test-schema.sql
       liquibase:
         change-log: classpath:db.changelog/db.gate.changelog-master.xml
+        default-schema: "eftiit"
     identifiers:
       driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-      jdbc-url: jdbc:tc:postgresql:15.4:///gate-test?user=efti&TC_DAEMON=true
+      jdbc-url: jdbc:tc:postgresql:15.4:///test?user=efti&TC_DAEMON=true&TC_INITSCRIPT=sql/init-test-schema.sql
       liquibase:
         change-log: classpath:db.changelog/db.identifiers.changelog-master.xml
+        default-schema: "eftiit"
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:
     properties:
       hibernate:
-        control_schema: "efti-it"
-        identifiers_schema: "efti-it"
+        control_schema: "eftiit"
+        identifiers_schema: "eftiit"
+        connection:
+          url: jdbc:tc:postgresql:15.4:///test?user=efti&TC_DAEMON=true&TC_INITSCRIPT=sql/init-test-schema.sql
   security:
     oauth2:
       resourceserver:
@@ -27,7 +31,7 @@ batch:
     cron: "0 */1 * ? * *"
 
 gate:
-  owner: it-tests
+  owner: gate-it
   country: IT
 
 logging:

--- a/implementation/gate/src/test/resources/application-it.yml
+++ b/implementation/gate/src/test/resources/application-it.yml
@@ -36,7 +36,5 @@ gate:
 
 logging:
   level:
-    reactor:
-      netty:
-        http:
-          client: DEBUG
+    eu.efti.eftigate.testsupport.TestDataRandomSeedResettingTestExecutionListener: TRACE
+    reactor.netty.http.client: DEBUG

--- a/implementation/gate/src/test/resources/application-it.yml
+++ b/implementation/gate/src/test/resources/application-it.yml
@@ -1,0 +1,38 @@
+spring:
+  datasource:
+    control:
+      driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+      jdbc-url: jdbc:tc:postgresql:15.4:///gate-test?user=efti&TC_DAEMON=true
+      liquibase:
+        change-log: classpath:db.changelog/db.gate.changelog-master.xml
+    identifiers:
+      driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+      jdbc-url: jdbc:tc:postgresql:15.4:///gate-test?user=efti&TC_DAEMON=true
+      liquibase:
+        change-log: classpath:db.changelog/db.identifiers.changelog-master.xml
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    properties:
+      hibernate:
+        control_schema: "efti-it"
+        identifiers_schema: "efti-it"
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost
+
+batch:
+  update:
+    cron: "0 */1 * ? * *"
+
+gate:
+  owner: it-tests
+  country: IT
+
+logging:
+  level:
+    reactor:
+      netty:
+        http:
+          client: DEBUG

--- a/implementation/gate/src/test/resources/sql/init-test-schema.sql
+++ b/implementation/gate/src/test/resources/sql/init-test-schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA eftiit;

--- a/implementation/platform-gate-simulator/pom.xml
+++ b/implementation/platform-gate-simulator/pom.xml
@@ -240,6 +240,20 @@
                             </sources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>
+                                    ${project.build.directory}/generated-sources/openapi/src/test/java
+                                </source>
+                            </sources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/implementation/platform-gate-simulator/pom.xml
+++ b/implementation/platform-gate-simulator/pom.xml
@@ -149,6 +149,14 @@
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>2.14.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>eu.efti</groupId>
+            <artifactId>test-support</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/implementation/platform-gate-simulator/pom.xml
+++ b/implementation/platform-gate-simulator/pom.xml
@@ -167,6 +167,13 @@
             <artifactId>modelmapper</artifactId>
         </dependency>
 
+        <!-- Required by gate client generated with openapi-generator -->
+        <dependency>
+            <groupId>io.github.threeten-jaxb</groupId>
+            <artifactId>threeten-jaxb-core</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -240,6 +247,7 @@
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>generate-api-for-gate</id>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>generate</goal>
@@ -254,12 +262,29 @@
                                 <useBeanValidation>false</useBeanValidation>
                                 <openApiNullable>false</openApiNullable>
                                 <useSpringBoot3>true</useSpringBoot3>
-                                // Using ${project.build.directory} fails the build on Windows
-                                <sourceFolder>build/generated-sources/src/main/java</sourceFolder>
                                 <withXml>true</withXml>
                                 <skipDefaultInterface>true</skipDefaultInterface>
                             </configOptions>
                             <apiPackage>eu.efti.platformgatesimulator.controller.api</apiPackage>
+                            <modelPackage>eu.efti.platformgatesimulator.dto</modelPackage>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-client-for-gate</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/../../schema/api-schemas/gate-api-for-platform.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>resttemplate</library>
+                            <configOptions>
+                                <openApiNullable>false</openApiNullable>
+                                <useJakartaEe>true</useJakartaEe>
+                                <withXml>true</withXml>
+                            </configOptions>
+                            <apiPackage>eu.efti.platformgatesimulator.service.client</apiPackage>
                             <modelPackage>eu.efti.platformgatesimulator.dto</modelPackage>
                         </configuration>
                     </execution>

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/PlatformGateSimulatorApplication.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/PlatformGateSimulatorApplication.java
@@ -1,11 +1,36 @@
 package eu.efti.platformgatesimulator;
 
+import eu.efti.platformgatesimulator.service.GateIntegrationService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
 
 @SpringBootApplication
+@Slf4j
 public class PlatformGateSimulatorApplication {
+    @Component
+    @AllArgsConstructor
+    public static class StartupRoutines {
+        private GateIntegrationService gateIntegrationService;
+
+        @EventListener
+        @Async
+        public void onApplicationEvent(@SuppressWarnings("unused") ApplicationStartedEvent event) {
+            try {
+                var whoami = gateIntegrationService.callWhoami();
+                log.info("Connected as {} to gate at {}", whoami, gateIntegrationService.getRestApiBaseUrl());
+            } catch (GateIntegrationService.GateIntegrationServiceException e) {
+                log.warn("Could not connect to gate at {} because of {}", gateIntegrationService.getRestApiBaseUrl(), e.getMessage());
+            } catch (Exception e) {
+                log.error("Unhandled error in startup routines", e);
+            }
+        }
+    }
 
     public static void main(final String[] args) {
         SpringApplication.run(PlatformGateSimulatorApplication.class, args);

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/config/GateProperties.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/config/GateProperties.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.net.URI;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -14,6 +16,7 @@ public class GateProperties {
     private String cdaPath;
     private String gate;
     private ApConfig ap;
+    private URI restApiBaseUrl;
     private int minSleep;
     private int maxSleep;
 

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/controller/IdentifiersController.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/controller/IdentifiersController.java
@@ -8,7 +8,7 @@ import eu.efti.platformgatesimulator.exception.UploadException;
 import eu.efti.platformgatesimulator.service.ApIncomingService;
 import eu.efti.platformgatesimulator.service.GateIntegrationService;
 import eu.efti.platformgatesimulator.service.ReaderService;
-import eu.efti.platformgatesimulator.utils.EftiSchemaUtils;
+import eu.efti.platformgatesimulator.utils.PlatformEftiSchemaUtils;
 import eu.efti.v1.json.SaveIdentifiersRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,7 +88,7 @@ public class IdentifiersController {
         var commonXml = readFileAsString(consignmentFile);
         try {
             var common = serializeUtils.mapXmlStringToJaxbObject(commonXml, eu.efti.v1.consignment.common.SupplyChainConsignment.class, EftiSchemas.getJavaCommonSchema());
-            var identifiers = EftiSchemaUtils.commonToIdentifiers(serializeUtils, common);
+            var identifiers = PlatformEftiSchemaUtils.commonToIdentifiers(serializeUtils, common);
             gateIntegrationService.uploadIdentifiers(datasetId, identifiers);
         } catch (SerializeUtils.MappingException e) {
             log.error("Could not map xml object", e);

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/controller/IdentifiersController.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/controller/IdentifiersController.java
@@ -1,35 +1,46 @@
 package eu.efti.platformgatesimulator.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import eu.efti.commons.dto.SearchWithIdentifiersRequestDto;
+import eu.efti.commons.exception.TechnicalException;
+import eu.efti.commons.utils.SerializeUtils;
+import eu.efti.datatools.schema.EftiSchemas;
 import eu.efti.platformgatesimulator.exception.UploadException;
 import eu.efti.platformgatesimulator.service.ApIncomingService;
-import eu.efti.platformgatesimulator.service.IdentifierService;
+import eu.efti.platformgatesimulator.service.GateIntegrationService;
 import eu.efti.platformgatesimulator.service.ReaderService;
+import eu.efti.platformgatesimulator.utils.EftiSchemaUtils;
 import eu.efti.v1.json.SaveIdentifiersRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
 @RestController
 @RequestMapping("/identifiers")
 @AllArgsConstructor
 @Slf4j
 public class IdentifiersController {
+    private static final Pattern datasetIdPattern = Pattern.compile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}");
 
     private final ApIncomingService apIncomingService;
 
     private final ReaderService readerService;
 
-    private final IdentifierService identifierService;
+    private final SerializeUtils serializeUtils;
+
+    private final GateIntegrationService gateIntegrationService;
 
     @PostMapping("/upload/file")
     public ResponseEntity<String> uploadFile(@RequestPart final MultipartFile file) {
@@ -60,5 +71,40 @@ public class IdentifiersController {
             return new ResponseEntity<>("No identifiers sent, error in JSON process", HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>("Identifiers uploaded", HttpStatus.OK);
+    }
+
+    @PutMapping("/upload/consignment/{datasetId}")
+    public ResponseEntity<String> uploadConsignment(
+            @PathVariable String datasetId,
+            @RequestPart final MultipartFile consignmentFile) {
+        if (consignmentFile == null || consignmentFile.isEmpty()) {
+            return new ResponseEntity<>("File is missing", HttpStatus.BAD_REQUEST);
+        }
+        if (!datasetIdPattern.matcher(datasetId).matches()) {
+            return new ResponseEntity<>("Dataset ID is not valid", HttpStatus.BAD_REQUEST);
+        }
+
+        log.info("Upload consignment {}", datasetId);
+        var commonXml = readFileAsString(consignmentFile);
+        try {
+            var common = serializeUtils.mapXmlStringToJaxbObject(commonXml, eu.efti.v1.consignment.common.SupplyChainConsignment.class, EftiSchemas.getJavaCommonSchema());
+            var identifiers = EftiSchemaUtils.commonToIdentifiers(serializeUtils, common);
+            gateIntegrationService.uploadIdentifiers(datasetId, identifiers);
+        } catch (SerializeUtils.MappingException e) {
+            log.error("Could not map xml object", e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid file: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Unhandled error", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+        return new ResponseEntity<>("Consignment saved and identifiers uploaded to gate", HttpStatus.OK);
+    }
+
+    private static String readFileAsString(MultipartFile file) {
+        try (var inputStream = file.getInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new TechnicalException("Error while reading attachment", e);
+        }
     }
 }

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/GateIntegrationService.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/GateIntegrationService.java
@@ -1,7 +1,10 @@
 package eu.efti.platformgatesimulator.service;
 
+import eu.efti.commons.utils.SerializeUtils;
 import eu.efti.platformgatesimulator.config.GateProperties;
 import eu.efti.platformgatesimulator.service.client.DefaultApi;
+import eu.efti.platformgatesimulator.utils.EftiSchemaUtils;
+import eu.efti.v1.consignment.identifier.SupplyChainConsignment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
@@ -21,9 +24,13 @@ public class GateIntegrationService {
 
     private final GateProperties gateProperties;
 
+    private final SerializeUtils serializeUtils;
+
     @Autowired
-    public GateIntegrationService(GateProperties gateProperties) {
+    public GateIntegrationService(GateProperties gateProperties,
+                                  SerializeUtils serializeUtils) {
         this.gateProperties = gateProperties;
+        this.serializeUtils = serializeUtils;
         var builder = new RestTemplateBuilder()
                 .defaultHeader("X-Mock-Pre-Authenticated-User-Id", gateProperties.getOwner())
                 .defaultHeader("X-Mock-Pre-Authenticated-User-Role", "PLATFORM");
@@ -38,6 +45,16 @@ public class GateIntegrationService {
     public String callWhoami() throws GateIntegrationServiceException {
         try {
             return api.getWhoami().getAppId();
+        } catch (HttpClientErrorException e) {
+            throw new GateIntegrationServiceException(e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    public void uploadIdentifiers(String datasetId, SupplyChainConsignment consignmentIdentifiers) throws GateIntegrationServiceException {
+        try {
+            var doc = EftiSchemaUtils.mapIdentifiersObjectToDoc(serializeUtils, consignmentIdentifiers);
+            var xml = serializeUtils.mapDocToXmlString(doc);
+            api.putConsignmentIdentifiers(datasetId, xml);
         } catch (HttpClientErrorException e) {
             throw new GateIntegrationServiceException(e.getClass().getSimpleName() + ": " + e.getMessage(), e);
         }

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/GateIntegrationService.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/GateIntegrationService.java
@@ -1,9 +1,9 @@
 package eu.efti.platformgatesimulator.service;
 
+import eu.efti.commons.utils.EftiSchemaUtils;
 import eu.efti.commons.utils.SerializeUtils;
 import eu.efti.platformgatesimulator.config.GateProperties;
 import eu.efti.platformgatesimulator.service.client.DefaultApi;
-import eu.efti.platformgatesimulator.utils.EftiSchemaUtils;
 import eu.efti.v1.consignment.identifier.SupplyChainConsignment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/GateIntegrationService.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/GateIntegrationService.java
@@ -1,0 +1,45 @@
+package eu.efti.platformgatesimulator.service;
+
+import eu.efti.platformgatesimulator.config.GateProperties;
+import eu.efti.platformgatesimulator.service.client.DefaultApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.net.URI;
+
+@Service
+public class GateIntegrationService {
+    public static class GateIntegrationServiceException extends Exception {
+        public GateIntegrationServiceException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private final DefaultApi api;
+
+    private final GateProperties gateProperties;
+
+    @Autowired
+    public GateIntegrationService(GateProperties gateProperties) {
+        this.gateProperties = gateProperties;
+        var builder = new RestTemplateBuilder()
+                .defaultHeader("X-Mock-Pre-Authenticated-User-Id", gateProperties.getOwner())
+                .defaultHeader("X-Mock-Pre-Authenticated-User-Role", "PLATFORM");
+        api = new DefaultApi(new ApiClient(builder.build())
+                .setBasePath(gateProperties.getRestApiBaseUrl().toString()));
+    }
+
+    public URI getRestApiBaseUrl() {
+        return gateProperties.getRestApiBaseUrl();
+    }
+
+    public String callWhoami() throws GateIntegrationServiceException {
+        try {
+            return api.getWhoami().getAppId();
+        } catch (HttpClientErrorException e) {
+            throw new GateIntegrationServiceException(e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/ReaderService.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/service/ReaderService.java
@@ -35,13 +35,17 @@ public class ReaderService {
     private final ResourceLoader resourceLoader;
 
     public void uploadFile(final MultipartFile file) throws UploadException {
+        uploadFile(file, file.getOriginalFilename());
+    }
+
+    public void uploadFile(final MultipartFile file, final String filenameOverride) throws UploadException {
         try {
             if (file == null) {
                 throw new NullPointerException("No file send");
             }
-            log.info("Try to upload file in {} with name {}", gateProperties.getCdaPath(), file.getOriginalFilename());
-            file.transferTo(new File(resourceLoader.getResource(gateProperties.getCdaPath()).getURI().getPath() + file.getOriginalFilename()));
-            log.info("File uploaded in {}", gateProperties.getCdaPath() + file.getOriginalFilename());
+            log.info("Try to upload file in {} with name {}", gateProperties.getCdaPath(), filenameOverride);
+            file.transferTo(new File(resourceLoader.getResource(gateProperties.getCdaPath()).getURI().getPath() + filenameOverride));
+            log.info("File uploaded in {}", gateProperties.getCdaPath() + filenameOverride);
         } catch (final IOException e) {
             log.error("Error when try to upload file to server", e);
             throw new UploadException(e);

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/utils/EftiSchemaUtils.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/utils/EftiSchemaUtils.java
@@ -1,0 +1,47 @@
+package eu.efti.platformgatesimulator.utils;
+
+import eu.efti.commons.utils.SerializeUtils;
+import eu.efti.datatools.schema.EftiSchemas;
+import eu.efti.datatools.schema.XmlSchemaElement;
+import eu.efti.datatools.schema.XmlUtil;
+import org.w3c.dom.Document;
+
+public class EftiSchemaUtils {
+    public static eu.efti.v1.consignment.identifier.SupplyChainConsignment commonToIdentifiers(
+            SerializeUtils serializeUtils,
+            eu.efti.v1.consignment.common.SupplyChainConsignment common) {
+        var doc = mapCommonObjectToDoc(serializeUtils, common);
+
+        var identifiersSchema = EftiSchemas.getConsignmentIdentifierSchema();
+        dropNodesNotInSchema(identifiersSchema, doc);
+
+        // Note: this is a dirty way of fixing the namespace, but it is simple and works in our context.
+        String identifiersXml = serializeUtils.mapDocToXmlString(doc).replace(
+                "http://efti.eu/v1/consignment/common",
+                "http://efti.eu/v1/consignment/identifier");
+
+        return serializeUtils.mapXmlStringToJaxbObject(
+                identifiersXml,
+                eu.efti.v1.consignment.identifier.SupplyChainConsignment.class,
+                EftiSchemas.getJavaIdentifiersSchema());
+    }
+
+    public static Document mapCommonObjectToDoc(
+            SerializeUtils serializeUtils,
+            eu.efti.v1.consignment.common.SupplyChainConsignment consignmentCommon) {
+        return serializeUtils.mapJaxbObjectToDoc(consignmentCommon, eu.efti.v1.consignment.common.SupplyChainConsignment.class,
+                "consignment", "http://efti.eu/v1/consignment/common");
+    }
+
+    public static Document mapIdentifiersObjectToDoc(
+            SerializeUtils serializeUtils,
+            eu.efti.v1.consignment.identifier.SupplyChainConsignment consignmentIdentifiers) {
+        return serializeUtils.mapJaxbObjectToDoc(consignmentIdentifiers, eu.efti.v1.consignment.identifier.SupplyChainConsignment.class,
+                "consignment", "http://efti.eu/v1/consignment/identifier");
+    }
+
+    private static void dropNodesNotInSchema(XmlSchemaElement schema, Document doc) {
+        XmlUtil.dropNodesRecursively(schema, doc.getFirstChild(), false,
+                (node, maybeSchemaElement) -> maybeSchemaElement == null);
+    }
+}

--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/utils/PlatformEftiSchemaUtils.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/utils/PlatformEftiSchemaUtils.java
@@ -1,16 +1,17 @@
 package eu.efti.platformgatesimulator.utils;
 
+import eu.efti.commons.utils.EftiSchemaUtils;
 import eu.efti.commons.utils.SerializeUtils;
 import eu.efti.datatools.schema.EftiSchemas;
 import eu.efti.datatools.schema.XmlSchemaElement;
 import eu.efti.datatools.schema.XmlUtil;
 import org.w3c.dom.Document;
 
-public class EftiSchemaUtils {
+public class PlatformEftiSchemaUtils {
     public static eu.efti.v1.consignment.identifier.SupplyChainConsignment commonToIdentifiers(
             SerializeUtils serializeUtils,
             eu.efti.v1.consignment.common.SupplyChainConsignment common) {
-        var doc = mapCommonObjectToDoc(serializeUtils, common);
+        var doc = EftiSchemaUtils.mapCommonObjectToDoc(serializeUtils, common);
 
         var identifiersSchema = EftiSchemas.getConsignmentIdentifierSchema();
         dropNodesNotInSchema(identifiersSchema, doc);
@@ -24,20 +25,6 @@ public class EftiSchemaUtils {
                 identifiersXml,
                 eu.efti.v1.consignment.identifier.SupplyChainConsignment.class,
                 EftiSchemas.getJavaIdentifiersSchema());
-    }
-
-    public static Document mapCommonObjectToDoc(
-            SerializeUtils serializeUtils,
-            eu.efti.v1.consignment.common.SupplyChainConsignment consignmentCommon) {
-        return serializeUtils.mapJaxbObjectToDoc(consignmentCommon, eu.efti.v1.consignment.common.SupplyChainConsignment.class,
-                "consignment", "http://efti.eu/v1/consignment/common");
-    }
-
-    public static Document mapIdentifiersObjectToDoc(
-            SerializeUtils serializeUtils,
-            eu.efti.v1.consignment.identifier.SupplyChainConsignment consignmentIdentifiers) {
-        return serializeUtils.mapJaxbObjectToDoc(consignmentIdentifiers, eu.efti.v1.consignment.identifier.SupplyChainConsignment.class,
-                "consignment", "http://efti.eu/v1/consignment/identifier");
     }
 
     private static void dropNodesNotInSchema(XmlSchemaElement schema, Document doc) {

--- a/implementation/platform-gate-simulator/src/main/resources/application.yml
+++ b/implementation/platform-gate-simulator/src/main/resources/application.yml
@@ -26,3 +26,6 @@ management:
     web:
       exposure:
         include: info,health,metrics
+
+gate:
+  restApiBaseUrl: http://localhost:83/api/platform

--- a/implementation/platform-gate-simulator/src/test/java/eu/efti/platformgatesimulator/controller/IdentifiersControllerTest.java
+++ b/implementation/platform-gate-simulator/src/test/java/eu/efti/platformgatesimulator/controller/IdentifiersControllerTest.java
@@ -1,9 +1,10 @@
 package eu.efti.platformgatesimulator.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.efti.commons.utils.SerializeUtils;
 import eu.efti.platformgatesimulator.exception.UploadException;
 import eu.efti.platformgatesimulator.service.ApIncomingService;
-import eu.efti.platformgatesimulator.service.IdentifierService;
+import eu.efti.platformgatesimulator.service.GateIntegrationService;
 import eu.efti.platformgatesimulator.service.ReaderService;
 import eu.efti.v1.json.Consignment;
 import eu.efti.v1.json.SaveIdentifiersRequest;
@@ -45,13 +46,16 @@ class IdentifiersControllerTest {
     private ReaderService readerService;
 
     @Mock
-    private IdentifierService identifierService;
+    private SerializeUtils serializeUtils;
+
+    @Mock
+    private GateIntegrationService gateIntegrationService;
 
     private final SaveIdentifiersRequest saveIdentifiersRequest = new SaveIdentifiersRequest();
 
     @BeforeEach
     void before() {
-        identifiersController = new IdentifiersController(apIncomingService, readerService, identifierService);
+        identifiersController = new IdentifiersController(apIncomingService, readerService, serializeUtils, gateIntegrationService);
         saveIdentifiersRequest.setRequestId("requestId");
         saveIdentifiersRequest.setConsignment(new Consignment());
         saveIdentifiersRequest.setDatasetId("datasetId");

--- a/implementation/platform-gate-simulator/src/test/java/eu/efti/platformgatesimulator/controller/IdentifiersControllerTest.java
+++ b/implementation/platform-gate-simulator/src/test/java/eu/efti/platformgatesimulator/controller/IdentifiersControllerTest.java
@@ -1,6 +1,8 @@
 package eu.efti.platformgatesimulator.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.efti.commons.utils.EftiSchemaUtils;
 import eu.efti.commons.utils.SerializeUtils;
 import eu.efti.platformgatesimulator.exception.UploadException;
 import eu.efti.platformgatesimulator.service.ApIncomingService;
@@ -25,8 +27,14 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
+import static eu.efti.testsupport.EntityFactory.newConsignmentCommon;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @WebMvcTest(IdentifiersController.class)
 @ContextConfiguration(classes = {IdentifiersController.class})
@@ -52,6 +60,15 @@ class IdentifiersControllerTest {
     private GateIntegrationService gateIntegrationService;
 
     private final SaveIdentifiersRequest saveIdentifiersRequest = new SaveIdentifiersRequest();
+
+    private static MockMultipartFile randomXmlMultipartFile() {
+        return xmlMultipartFile("<some-xml/>");
+    }
+
+    private static MockMultipartFile xmlMultipartFile(String content) {
+        return new MockMultipartFile("some-file.xml", "some-original-filename.xml",
+                "application/xml", content.getBytes(StandardCharsets.UTF_8));
+    }
 
     @BeforeEach
     void before() {
@@ -116,6 +133,36 @@ class IdentifiersControllerTest {
     }
 
     @Test
+    void uploadConsignmentHappyPathTest() {
+        var actualSerializeUtils = new SerializeUtils(new ObjectMapper());
+
+        var common = newConsignmentCommon();
+        var file = xmlMultipartFile(actualSerializeUtils.mapDocToXmlString(EftiSchemaUtils.mapCommonObjectToDoc(actualSerializeUtils, common), true));
+        var datasetId = UUID.randomUUID().toString();
+
+        // Testing happy path requires actual serialization implementation
+        ResponseEntity<String> result = new IdentifiersController(apIncomingService, readerService, actualSerializeUtils, gateIntegrationService)
+                .uploadConsignment(datasetId, file);
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(HttpStatus.OK, result.getStatusCode()),
+                () -> Assertions.assertEquals("Consignment saved and identifiers uploaded to gate", result.getBody())
+        );
+
+        try {
+            verify(gateIntegrationService, times(1)).uploadIdentifiers(
+                    eq(datasetId),
+                    argThat(identifier -> {
+                        // Make some minimal assertion that verifies the identifier object is created from common object.
+                        return identifier.getCarrierAcceptanceDateTime().getValue().equals(common.getCarrierAcceptanceDateTime().getValue());
+                    }));
+            verify(readerService, times(1)).uploadFile(file, "%s.xml".formatted(datasetId));
+        } catch (GateIntegrationService.GateIntegrationServiceException | UploadException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
     void uploadConsignmentNullFileTest() {
         final ResponseEntity<String> result = identifiersController.uploadConsignment(null, null);
 
@@ -127,8 +174,7 @@ class IdentifiersControllerTest {
 
     @Test
     void uploadConsignmentNullDatasetIdTest() {
-        MockMultipartFile file = new MockMultipartFile("data", "other-file-name.xml", "application/xml", "some other type".getBytes(StandardCharsets.UTF_8));
-        final ResponseEntity<String> result = identifiersController.uploadConsignment(null, file);
+        final ResponseEntity<String> result = identifiersController.uploadConsignment(null, randomXmlMultipartFile());
 
         Assertions.assertAll(
                 () -> Assertions.assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode()),
@@ -138,8 +184,7 @@ class IdentifiersControllerTest {
 
     @Test
     void uploadConsignmentInvalidDatasetIdTest() {
-        MockMultipartFile file = new MockMultipartFile("data", "other-file-name.xml", "application/xml", "some other type".getBytes(StandardCharsets.UTF_8));
-        final ResponseEntity<String> result = identifiersController.uploadConsignment("sone-invalid-dataset-id", file);
+        final ResponseEntity<String> result = identifiersController.uploadConsignment("sone-invalid-dataset-id", randomXmlMultipartFile());
 
         Assertions.assertAll(
                 () -> Assertions.assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode()),

--- a/implementation/platform-gate-simulator/src/test/java/eu/efti/platformgatesimulator/controller/IdentifiersControllerTest.java
+++ b/implementation/platform-gate-simulator/src/test/java/eu/efti/platformgatesimulator/controller/IdentifiersControllerTest.java
@@ -115,4 +115,35 @@ class IdentifiersControllerTest {
         Assertions.assertEquals("No identifiers sent, error in JSON process", result.getBody());
     }
 
+    @Test
+    void uploadConsignmentNullFileTest() {
+        final ResponseEntity<String> result = identifiersController.uploadConsignment(null, null);
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode()),
+                () -> Assertions.assertEquals("File is missing", result.getBody())
+        );
+    }
+
+    @Test
+    void uploadConsignmentNullDatasetIdTest() {
+        MockMultipartFile file = new MockMultipartFile("data", "other-file-name.xml", "application/xml", "some other type".getBytes(StandardCharsets.UTF_8));
+        final ResponseEntity<String> result = identifiersController.uploadConsignment(null, file);
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode()),
+                () -> Assertions.assertEquals("Dataset ID is not valid", result.getBody())
+        );
+    }
+
+    @Test
+    void uploadConsignmentInvalidDatasetIdTest() {
+        MockMultipartFile file = new MockMultipartFile("data", "other-file-name.xml", "application/xml", "some other type".getBytes(StandardCharsets.UTF_8));
+        final ResponseEntity<String> result = identifiersController.uploadConsignment("sone-invalid-dataset-id", file);
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode()),
+                () -> Assertions.assertEquals("Dataset ID is not valid", result.getBody())
+        );
+    }
 }

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -134,6 +134,7 @@
         <module>gate</module>
         <module>platform-gate-simulator</module>
         <module>efti-ws-plugin</module>
+        <module>test-support</module>
     </modules>
 
     <dependencyManagement>

--- a/implementation/test-support/README.md
+++ b/implementation/test-support/README.md
@@ -1,0 +1,3 @@
+# Test Support
+
+Test utilities shared by other modules.

--- a/implementation/test-support/pom.xml
+++ b/implementation/test-support/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.efti</groupId>
+        <artifactId>gate-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>test-support</artifactId>
+
+    <properties>
+        <sonar.coverage.exclusions>
+            **/enums/**.java, **/dto/**.java, **/constant/**.java, **/utils/**.java, **/exception/**.java,
+        </sonar.coverage.exclusions>
+    </properties>
+    <name>test-support</name>
+    <description>Test support utilities</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.efti</groupId>
+            <artifactId>commons</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+    </build>
+</project>

--- a/implementation/test-support/sonar-project.properties
+++ b/implementation/test-support/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.coverage.exclusions=**/enums/**.java, **/dto/**.java, **/constant/**.java, **/utils/**.java, **/exception/**.java

--- a/implementation/test-support/src/main/java/eu/efti/testsupport/EntityFactory.java
+++ b/implementation/test-support/src/main/java/eu/efti/testsupport/EntityFactory.java
@@ -1,0 +1,104 @@
+package eu.efti.testsupport;
+
+import eu.efti.v1.codes.CountryCode;
+import eu.efti.v1.codes.TransportEquipmentCategoryCode;
+import eu.efti.v1.consignment.common.TradeParty;
+import eu.efti.v1.types.DateTime;
+import eu.efti.v1.types.Identifier17;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import static eu.efti.testsupport.TestData.random;
+import static eu.efti.testsupport.TestData.randomBoolean;
+import static eu.efti.testsupport.TestData.randomFutureInstant;
+import static eu.efti.testsupport.TestData.randomIdentifier;
+import static eu.efti.testsupport.TestData.randomPastInstant;
+
+public class EntityFactory {
+    public static eu.efti.v1.consignment.common.SupplyChainConsignment newConsignmentCommon() {
+        eu.efti.v1.consignment.common.SupplyChainConsignment c = new eu.efti.v1.consignment.common.SupplyChainConsignment();
+
+        c.setCarrier(new TradeParty());
+        c.getCarrier().setId(newIdentifier17());
+
+        c.setCarrierAcceptanceDateTime(newDateTime(randomPastInstant()));
+
+        c.setDeliveryEvent(new  eu.efti.v1.consignment.common.TransportEvent());
+        c.getDeliveryEvent().setActualOccurrenceDateTime(newDateTime(randomFutureInstant()));
+
+        var ltmo = new  eu.efti.v1.consignment.common.LogisticsTransportMovement();
+        ltmo.setDangerousGoodsIndicator(randomBoolean());
+        ltmo.setModeCode(random("1", "2", "3", "4"));
+        ltmo.setUsedTransportMeans(new eu.efti.v1.consignment.common.LogisticsTransportMeans());
+        ltmo.getUsedTransportMeans().setId(newIdentifier17());
+        ltmo.getUsedTransportMeans().setRegistrationCountry(newCommonTradeCountry());
+        c.getMainCarriageTransportMovement().add(ltmo);
+
+        var lte = new eu.efti.v1.consignment.common.LogisticsTransportEquipment();
+        lte.setId(newIdentifier17());
+        lte.setCategoryCode(random(TransportEquipmentCategoryCode.class));
+        lte.setRegistrationCountry(newCommonTradeCountry());
+        lte.setSequenceNumber(BigInteger.ONE);
+        c.getUsedTransportEquipment().add(lte);
+
+        return c;
+    }
+
+    public static eu.efti.v1.consignment.identifier.SupplyChainConsignment newConsignmentIdentifier() {
+        eu.efti.v1.consignment.identifier.SupplyChainConsignment c = new eu.efti.v1.consignment.identifier.SupplyChainConsignment();
+
+        c.setCarrierAcceptanceDateTime(newDateTime(randomPastInstant()));
+
+        c.setDeliveryEvent(new  eu.efti.v1.consignment.identifier.TransportEvent());
+        c.getDeliveryEvent().setActualOccurrenceDateTime(newDateTime(randomFutureInstant()));
+
+        var ltmo = new  eu.efti.v1.consignment.identifier.LogisticsTransportMovement();
+        ltmo.setDangerousGoodsIndicator(randomBoolean());
+        ltmo.setModeCode(random("1", "2", "3", "4"));
+        ltmo.setUsedTransportMeans(new eu.efti.v1.consignment.identifier.LogisticsTransportMeans());
+        ltmo.getUsedTransportMeans().setId(newIdentifier17());
+        ltmo.getUsedTransportMeans().setRegistrationCountry(newIdentifierTradeCountry());
+        c.getMainCarriageTransportMovement().add(ltmo);
+
+        var lte = new eu.efti.v1.consignment.identifier.LogisticsTransportEquipment();
+        lte.setId(newIdentifier17());
+        lte.setCategoryCode(random(TransportEquipmentCategoryCode.class));
+        lte.setRegistrationCountry(newIdentifierTradeCountry());
+        lte.setSequenceNumber(BigInteger.ONE);
+        c.getUsedTransportEquipment().add(lte);
+
+        return c;
+    }
+
+    private static eu.efti.v1.consignment.identifier.TradeCountry newIdentifierTradeCountry() {
+        var tc = new eu.efti.v1.consignment.identifier.TradeCountry();
+        tc.setCode(random(CountryCode.class));
+        return tc;
+    }
+
+    private static eu.efti.v1.consignment.common.TradeCountry newCommonTradeCountry() {
+        var tc = new eu.efti.v1.consignment.common.TradeCountry();
+        tc.setCode(random(CountryCode.class));
+        return tc;
+    }
+
+    private static Identifier17 newIdentifier17() {
+        var id = new Identifier17();
+        id.setValue(randomIdentifier());
+        return id;
+    }
+
+    private static DateTime newDateTime(Instant instant) {
+        var dateTime = new DateTime();
+        dateTime.setFormatId("205");
+        dateTime.setValue(OffsetDateTime
+                .ofInstant(instant.truncatedTo(ChronoUnit.MINUTES), ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmZ")));
+        return dateTime;
+    }
+}

--- a/implementation/test-support/src/main/java/eu/efti/testsupport/TestData.java
+++ b/implementation/test-support/src/main/java/eu/efti/testsupport/TestData.java
@@ -1,4 +1,4 @@
-package eu.efti.eftigate.testsupport;
+package eu.efti.testsupport;
 
 import org.apache.commons.lang3.RandomStringUtils;
 

--- a/utils/eFTI.postman_collection.json
+++ b/utils/eFTI.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "110cd8cc-a7f9-4cb4-836b-b5748fbee108",
+		"_postman_id": "bfa23f25-89cf-4251-ab9a-5955ea954be0",
 		"name": "eFTI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "30836777"
+		"_exporter_id": "43604470"
 	},
 	"item": [
 		{
@@ -556,6 +556,46 @@
 									"path": [
 										"identifiers",
 										"upload"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Upload Consignment",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{access_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "consignmentFile",
+											"type": "file",
+											"src": []
+										}
+									]
+								},
+								"url": {
+									"raw": "{{simulator_bo_url}}/identifiers/upload/consignment/{{datasetId}}",
+									"host": [
+										"{{simulator_bo_url}}"
+									],
+									"path": [
+										"identifiers",
+										"upload",
+										"consignment",
+										"{{datasetId}}"
 									]
 								}
 							},


### PR DESCRIPTION
* Implement gate REST api for platform.
* Add new endpoint to platform-simulator for testing this (along with postman test case). 
* Authentication is based on pre-authentication: gate expects load balancer (or similar component) to take care of authentication and to add headers that identify the client and role. 
* For local testing, Apache proxy supports mock headers.
* Set up integration tests: whole spring context is loaded for tests, database is run via testcontainers, database tables are cleared between tests

Local testing is possible with:
* postman
* command line: `curl -v -H 'X-Mock-Pre-Authenticated-User-Id: my-platform' -H 'X-Mock-Pre-Authenticated-User-Role: PLATFORM' http://localhost:83/api/platform/v0/whoami`