### PR TITLE
EREF-25 update remove TODO markers

### DIFF
--- a/deploy/local/domibus/pmodes/borduria-pmode.xml
+++ b/deploy/local/domibus/pmodes/borduria-pmode.xml
@@ -36,7 +36,6 @@
              endpoint="http://efti.gate.listenbourg.eu:81/domibus/services/msh?domain=listenbourg">
         <identifier partyId="listenbourg" partyIdType="partyTypeUrn"/>
       </party>
-      <!-- TODO EREF-25: should we remove this since acme is configured to uses REST api -->
       <party name="acme"
              endpoint="http://efti.platform.acme.com:81/domibus/services/msh?domain=acme">
         <identifier partyId="acme" partyIdType="partyTypeUrn"/>

--- a/implementation/gate/src/main/java/eu/efti/eftigate/service/PlatformRestService.java
+++ b/implementation/gate/src/main/java/eu/efti/eftigate/service/PlatformRestService.java
@@ -27,7 +27,7 @@ public class PlatformRestService {
     private final ValidationService validationService;
 
     private static DefaultApi createApi(URI restApiBaseUrl) {
-        // TODO EREF-25: is authentication required?
+        // TODO EREF-72: include authentication info
         return new DefaultApi(new ApiClient(restTemplate)
                 .setBasePath(restApiBaseUrl.toString()));
     }


### PR DESCRIPTION
We don't need to remove the pmode config for borduria. Perhaps we still want to switch between REST and eDelivery for testing.