### PR TITLE
Add requestId to SaveIdentifiersRequest in the platform simulator

### DIFF
--- a/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/mapper/MapperUtils.java
+++ b/implementation/platform-gate-simulator/src/main/java/eu/efti/platformgatesimulator/mapper/MapperUtils.java
@@ -11,6 +11,7 @@ import eu.efti.v1.json.UsedTransportMeans;
 
 import java.math.BigInteger;
 import java.util.stream.Collectors;
+import java.util.UUID;
 
 public class MapperUtils {
 
@@ -20,6 +21,7 @@ public class MapperUtils {
         }
         eu.efti.v1.edelivery.SaveIdentifiersRequest resultSaveIdentifiersRequest = new eu.efti.v1.edelivery.SaveIdentifiersRequest();
         resultSaveIdentifiersRequest.setDatasetId(sourceSaveIdentifiersRequest.getDatasetId());
+        resultSaveIdentifiersRequest.setRequestId(UUID.randomUUID().toString());
         resultSaveIdentifiersRequest.setConsignment(from(sourceSaveIdentifiersRequest.getConsignment()));
         return resultSaveIdentifiersRequest;
     }


### PR DESCRIPTION
Currently the platform save-identifier requests sent by the platform-simulator are discarded by the gate because they do not include a requestId and are therefore invalid.

This small fix adds a randomly generated requestId to the save-identifiers request to address this issue.