### PR TITLE
local: disable domibus connection monitoring on "default" domains

### DIFF
--- a/deploy/local/domibus/domibus/li/domibus-li.properties
+++ b/deploy/local/domibus/domibus/li/domibus-li.properties
@@ -1036,10 +1036,10 @@ domibus.pull.retry.cron=0/20 * * ? * * *
 #domibus.monitoring.connection.party.history.delete=ALL
 
 #Cron expression that specifies the frequency of test messages sent to monitor the C2-C3 connections
-#domibus.monitoring.connection.cron=0 0 0/2 ? * * *
+domibus.monitoring.connection.cron=0 0 0/2 ? * * 3001 # disabled by setting the year into far future
 
 #Cron expression that specifies the frequency of test messages sent to itself (e.g. C2-C2 connections)
-#domibus.monitoring.connection.self.cron=0 0 0/1 ? * * *
+domibus.monitoring.connection.self.cron=0 0 0/1 ? * * 3001 # disabled by setting the year into far future
 
 #Cron expression that specifies the frequency of deleting test message history sent to gateway party
 #domibus.monitoring.connection.messages.received.history.delete.cron=0 0 0/1 ? * * *

--- a/deploy/local/domibus/domibus/platform/domibus-platform.properties
+++ b/deploy/local/domibus/domibus/platform/domibus-platform.properties
@@ -1036,10 +1036,10 @@ domibus.pull.retry.cron=0/20 * * ? * * *
 #domibus.monitoring.connection.party.history.delete=ALL
 
 #Cron expression that specifies the frequency of test messages sent to monitor the C2-C3 connections
-#domibus.monitoring.connection.cron=0 0 0/2 ? * * *
+domibus.monitoring.connection.cron=0 0 0/2 ? * * 3001 # disabled by setting the year into far future
 
 #Cron expression that specifies the frequency of test messages sent to itself (e.g. C2-C2 connections)
-#domibus.monitoring.connection.self.cron=0 0 0/1 ? * * *
+domibus.monitoring.connection.self.cron=0 0 0/1 ? * * 3001 # disabled by setting the year into far future
 
 #Cron expression that specifies the frequency of deleting test message history sent to gateway party
 #domibus.monitoring.connection.messages.received.history.delete.cron=0 0 0/1 ? * * *

--- a/deploy/local/domibus/domibus/sybo/domibus-sybo.properties
+++ b/deploy/local/domibus/domibus/sybo/domibus-sybo.properties
@@ -1036,10 +1036,10 @@ domibus.pull.retry.cron=0/20 * * ? * * *
 #domibus.monitoring.connection.party.history.delete=ALL
 
 #Cron expression that specifies the frequency of test messages sent to monitor the C2-C3 connections
-#domibus.monitoring.connection.cron=0 0 0/2 ? * * *
+domibus.monitoring.connection.cron=0 0 0/2 ? * * 3001 # disabled by setting the year into far future
 
 #Cron expression that specifies the frequency of test messages sent to itself (e.g. C2-C2 connections)
-#domibus.monitoring.connection.self.cron=0 0 0/1 ? * * *
+domibus.monitoring.connection.self.cron=0 0 0/1 ? * * 3001 # disabled by setting the year into far future
 
 #Cron expression that specifies the frequency of deleting test message history sent to gateway party
 #domibus.monitoring.connection.messages.received.history.delete.cron=0 0 0/1 ? * * *


### PR DESCRIPTION
In the multitenant domibuses, there were errors in logs related to monitoring jobs. Apparently the default config for "default" domain does not work when running in multitenant mode. So just disable these monitoring jobs.

The error in logs was:

    domibus-sybo-1  | 2026-06-15 12:00:00,191 [] [] [] [] [null_Worker-90] ERROR o.q.c.ErrorLogger:2407 - Job (DEFAULT.deleteTestMessageHistoryJob threw an exception.
    domibus-sybo-1  | org.quartz.SchedulerException: Job threw an unhandled exception.
    domibus-sybo-1  | 	at org.quartz.core.JobRunShell.run(JobRunShell.java:213)
    domibus-sybo-1  | 	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
    domibus-sybo-1  | Caused by: java.lang.IllegalStateException: No processing modes found. To exchange messages, upload configuration file through the web gui.