### PR TITLE
Fix domibus startup problem caused by monitoring job cron

### DIFF
--- a/deploy/local/domibus/domibus/li/domibus-li.properties
+++ b/deploy/local/domibus/domibus/li/domibus-li.properties
@@ -1036,10 +1036,10 @@ domibus.pull.retry.cron=0/20 * * ? * * *
 #domibus.monitoring.connection.party.history.delete=ALL
 
 #Cron expression that specifies the frequency of test messages sent to monitor the C2-C3 connections
-domibus.monitoring.connection.cron=0 0 0/2 ? * * 3001 # disabled by setting the year into far future
+#domibus.monitoring.connection.cron=0 0 0/2 ? * * *
 
 #Cron expression that specifies the frequency of test messages sent to itself (e.g. C2-C2 connections)
-domibus.monitoring.connection.self.cron=0 0 0/1 ? * * 3001 # disabled by setting the year into far future
+#domibus.monitoring.connection.self.cron=0 0 0/1 ? * * *
 
 #Cron expression that specifies the frequency of deleting test message history sent to gateway party
 #domibus.monitoring.connection.messages.received.history.delete.cron=0 0 0/1 ? * * *

--- a/deploy/local/domibus/domibus/platform/domibus-platform.properties
+++ b/deploy/local/domibus/domibus/platform/domibus-platform.properties
@@ -1036,10 +1036,10 @@ domibus.pull.retry.cron=0/20 * * ? * * *
 #domibus.monitoring.connection.party.history.delete=ALL
 
 #Cron expression that specifies the frequency of test messages sent to monitor the C2-C3 connections
-domibus.monitoring.connection.cron=0 0 0/2 ? * * 3001 # disabled by setting the year into far future
+#domibus.monitoring.connection.cron=0 0 0/2 ? * * *
 
 #Cron expression that specifies the frequency of test messages sent to itself (e.g. C2-C2 connections)
-domibus.monitoring.connection.self.cron=0 0 0/1 ? * * 3001 # disabled by setting the year into far future
+#domibus.monitoring.connection.self.cron=0 0 0/1 ? * * *
 
 #Cron expression that specifies the frequency of deleting test message history sent to gateway party
 #domibus.monitoring.connection.messages.received.history.delete.cron=0 0 0/1 ? * * *

--- a/deploy/local/domibus/domibus/sybo/domibus-sybo.properties
+++ b/deploy/local/domibus/domibus/sybo/domibus-sybo.properties
@@ -1036,10 +1036,10 @@ domibus.pull.retry.cron=0/20 * * ? * * *
 #domibus.monitoring.connection.party.history.delete=ALL
 
 #Cron expression that specifies the frequency of test messages sent to monitor the C2-C3 connections
-domibus.monitoring.connection.cron=0 0 0/2 ? * * 3001 # disabled by setting the year into far future
+#domibus.monitoring.connection.cron=0 0 0/2 ? * * *
 
 #Cron expression that specifies the frequency of test messages sent to itself (e.g. C2-C2 connections)
-domibus.monitoring.connection.self.cron=0 0 0/1 ? * * 3001 # disabled by setting the year into far future
+#domibus.monitoring.connection.self.cron=0 0 0/1 ? * * *
 
 #Cron expression that specifies the frequency of deleting test message history sent to gateway party
 #domibus.monitoring.connection.messages.received.history.delete.cron=0 0 0/1 ? * * *


### PR DESCRIPTION
Revert "local: disable domibus connection monitoring on "default" domains (#87)"

This reverts commit bfc8b15037fa07c226f8be7cf05d4d5e8c1daf1c.